### PR TITLE
feat: add circular prop to arc element draw actions

### DIFF
--- a/src/core/core.datasetController.js
+++ b/src/core/core.datasetController.js
@@ -674,6 +674,8 @@ export default class DatasetController {
     const ctx = this._ctx;
     const chart = this.chart;
     const meta = this._cachedMeta;
+    const scale = meta.rScale || {};
+    const scaleOptions = scale.options || {};
     const elements = meta.data || [];
     const area = chart.chartArea;
     const active = [];
@@ -694,12 +696,12 @@ export default class DatasetController {
       if (element.active && drawActiveElementsOnTop) {
         active.push(element);
       } else {
-        element.draw(ctx, area);
+        element.draw(ctx, area, scaleOptions);
       }
     }
 
     for (i = 0; i < active.length; ++i) {
-      active[i].draw(ctx, area);
+      active[i].draw(ctx, area, scaleOptions);
     }
   }
 

--- a/src/elements/element.arc.js
+++ b/src/elements/element.arc.js
@@ -93,7 +93,7 @@ function rThetaToXY(r, theta, x, y) {
  * @param {CanvasRenderingContext2D} ctx
  * @param {ArcElement} element
  */
-function pathArc(ctx, element, offset, spacing, end) {
+function pathArc(ctx, element, offset, spacing, end, scaleOptions) {
   const {x, y, startAngle: start, pixelMargin, innerRadius: innerR} = element;
 
   const outerRadius = Math.max(element.outerRadius + spacing + offset - pixelMargin, 0);
@@ -129,54 +129,71 @@ function pathArc(ctx, element, offset, spacing, end) {
   const innerStartAdjustedAngle = startAngle + innerStart / innerStartAdjustedRadius;
   const innerEndAdjustedAngle = endAngle - innerEnd / innerEndAdjustedRadius;
 
+  let circular = true;
+  if (scaleOptions !== undefined && scaleOptions.grid !== undefined && scaleOptions.grid.circular === false) {
+    circular = false;
+  }
+
   ctx.beginPath();
 
-  // The first arc segment from point 1 to point 2
-  ctx.arc(x, y, outerRadius, outerStartAdjustedAngle, outerEndAdjustedAngle);
+  if (circular) {
+    // The first arc segment from point 1 to point 2
+    ctx.arc(x, y, outerRadius, outerStartAdjustedAngle, outerEndAdjustedAngle);
 
-  // The corner segment from point 2 to point 3
-  if (outerEnd > 0) {
-    const pCenter = rThetaToXY(outerEndAdjustedRadius, outerEndAdjustedAngle, x, y);
-    ctx.arc(pCenter.x, pCenter.y, outerEnd, outerEndAdjustedAngle, endAngle + HALF_PI);
-  }
+    // The corner segment from point 2 to point 3
+    if (outerEnd > 0) {
+      const pCenter = rThetaToXY(outerEndAdjustedRadius, outerEndAdjustedAngle, x, y);
+      ctx.arc(pCenter.x, pCenter.y, outerEnd, outerEndAdjustedAngle, endAngle + HALF_PI);
+    }
 
-  // The line from point 3 to point 4
-  const p4 = rThetaToXY(innerEndAdjustedRadius, endAngle, x, y);
-  ctx.lineTo(p4.x, p4.y);
+    // The line from point 3 to point 4
+    const p4 = rThetaToXY(innerEndAdjustedRadius, endAngle, x, y);
+    ctx.lineTo(p4.x, p4.y);
 
-  // The corner segment from point 4 to point 5
-  if (innerEnd > 0) {
-    const pCenter = rThetaToXY(innerEndAdjustedRadius, innerEndAdjustedAngle, x, y);
-    ctx.arc(pCenter.x, pCenter.y, innerEnd, endAngle + HALF_PI, innerEndAdjustedAngle + Math.PI);
-  }
+    // The corner segment from point 4 to point 5
+    if (innerEnd > 0) {
+      const pCenter = rThetaToXY(innerEndAdjustedRadius, innerEndAdjustedAngle, x, y);
+      ctx.arc(pCenter.x, pCenter.y, innerEnd, endAngle + HALF_PI, innerEndAdjustedAngle + Math.PI);
+    }
 
-  // The inner arc from point 5 to point 6
-  ctx.arc(x, y, innerRadius, endAngle - (innerEnd / innerRadius), startAngle + (innerStart / innerRadius), true);
+    // The inner arc from point 5 to point 6
+    ctx.arc(x, y, innerRadius, endAngle - (innerEnd / innerRadius), startAngle + (innerStart / innerRadius), true);
 
-  // The corner segment from point 6 to point 7
-  if (innerStart > 0) {
-    const pCenter = rThetaToXY(innerStartAdjustedRadius, innerStartAdjustedAngle, x, y);
-    ctx.arc(pCenter.x, pCenter.y, innerStart, innerStartAdjustedAngle + Math.PI, startAngle - HALF_PI);
-  }
+    // The corner segment from point 6 to point 7
+    if (innerStart > 0) {
+      const pCenter = rThetaToXY(innerStartAdjustedRadius, innerStartAdjustedAngle, x, y);
+      ctx.arc(pCenter.x, pCenter.y, innerStart, innerStartAdjustedAngle + Math.PI, startAngle - HALF_PI);
+    }
 
-  // The line from point 7 to point 8
-  const p8 = rThetaToXY(outerStartAdjustedRadius, startAngle, x, y);
-  ctx.lineTo(p8.x, p8.y);
+    // The line from point 7 to point 8
+    const p8 = rThetaToXY(outerStartAdjustedRadius, startAngle, x, y);
+    ctx.lineTo(p8.x, p8.y);
 
-  // The corner segment from point 8 to point 1
-  if (outerStart > 0) {
-    const pCenter = rThetaToXY(outerStartAdjustedRadius, outerStartAdjustedAngle, x, y);
-    ctx.arc(pCenter.x, pCenter.y, outerStart, startAngle - HALF_PI, outerStartAdjustedAngle);
+    // The corner segment from point 8 to point 1
+    if (outerStart > 0) {
+      const pCenter = rThetaToXY(outerStartAdjustedRadius, outerStartAdjustedAngle, x, y);
+      ctx.arc(pCenter.x, pCenter.y, outerStart, startAngle - HALF_PI, outerStartAdjustedAngle);
+    }
+  } else {
+    ctx.moveTo(x, y);
+
+    const outerStartX = Math.cos(outerStartAdjustedAngle) * outerRadius + x;
+    const outerStartY = Math.sin(outerStartAdjustedAngle) * outerRadius + y;
+    ctx.lineTo(outerStartX, outerStartY);
+
+    const outerEndX = Math.cos(outerEndAdjustedAngle) * outerRadius + x;
+    const outerEndY = Math.sin(outerEndAdjustedAngle) * outerRadius + y;
+    ctx.lineTo(outerEndX, outerEndY);
   }
 
   ctx.closePath();
 }
 
-function drawArc(ctx, element, offset, spacing) {
+function drawArc(ctx, element, offset, spacing, scaleOptions) {
   const {fullCircles, startAngle, circumference} = element;
   let endAngle = element.endAngle;
   if (fullCircles) {
-    pathArc(ctx, element, offset, spacing, startAngle + TAU);
+    pathArc(ctx, element, offset, spacing, startAngle + TAU, scaleOptions);
 
     for (let i = 0; i < fullCircles; ++i) {
       ctx.fill();
@@ -189,8 +206,7 @@ function drawArc(ctx, element, offset, spacing) {
       }
     }
   }
-
-  pathArc(ctx, element, offset, spacing, endAngle);
+  pathArc(ctx, element, offset, spacing, endAngle, scaleOptions);
   ctx.fill();
   return endAngle;
 }
@@ -219,7 +235,7 @@ function drawFullCircleBorders(ctx, element, inner) {
   }
 }
 
-function drawBorder(ctx, element, offset, spacing, endAngle) {
+function drawBorder(ctx, element, offset, spacing, endAngle, scaleOptions) {
   const {options} = element;
   const {borderWidth, borderJoinStyle} = options;
   const inner = options.borderAlign === 'inner';
@@ -244,7 +260,7 @@ function drawBorder(ctx, element, offset, spacing, endAngle) {
     clipArc(ctx, element, endAngle);
   }
 
-  pathArc(ctx, element, offset, spacing, endAngle);
+  pathArc(ctx, element, offset, spacing, endAngle, scaleOptions);
   ctx.stroke();
 }
 
@@ -319,7 +335,7 @@ export default class ArcElement extends Element {
     return this.getCenterPoint(useFinalPosition);
   }
 
-  draw(ctx) {
+  draw(ctx, _area, scaleOptions) {
     const {options, circumference} = this;
     const offset = (options.offset || 0) / 2;
     const spacing = (options.spacing || 0) / 2;
@@ -345,8 +361,8 @@ export default class ArcElement extends Element {
     ctx.fillStyle = options.backgroundColor;
     ctx.strokeStyle = options.borderColor;
 
-    const endAngle = drawArc(ctx, this, radiusOffset, spacing);
-    drawBorder(ctx, this, radiusOffset, spacing, endAngle);
+    const endAngle = drawArc(ctx, this, radiusOffset, spacing, scaleOptions);
+    drawBorder(ctx, this, radiusOffset, spacing, endAngle, scaleOptions);
 
     ctx.restore();
   }

--- a/test/specs/element.arc.tests.js
+++ b/test/specs/element.arc.tests.js
@@ -218,4 +218,31 @@ describe('Arc element tests', function() {
 
     expect(ctx.getCalls().length).toBe(0);
   });
+
+  it('should draw when circular: false', function() {
+    var arc = new Chart.elements.ArcElement({
+      startAngle: 0,
+      endAngle: Math.PI * 2,
+      x: 2,
+      y: 2,
+      innerRadius: 0,
+      outerRadius: 2,
+      options: {
+        spacing: 0,
+        offset: 0,
+        scales: {
+          r: {
+            grid: {
+              circular: false,
+            },
+          },
+        }
+      }
+    });
+
+    var ctx = window.createMockContext();
+    arc.draw(ctx);
+
+    expect(ctx.getCalls().length).toBeGreaterThan(0);
+  });
 });


### PR DESCRIPTION
Make Arc Elements depended on Circular prop. From issue https://github.com/chartjs/Chart.js/issues/10357

You can check the build with changes [here](https://codesandbox.io/s/elegant-gauss-i3txuf?file=/src/components/PolarChart.ts)